### PR TITLE
Add package upgrade at system startup and periodically

### DIFF
--- a/recipes-connectivity/cube-update/cube-update/config.default
+++ b/recipes-connectivity/cube-update/cube-update/config.default
@@ -1,0 +1,39 @@
+#!/bin/false  This file must be sourced
+#
+# Copyright (C) 2015 Wind River Systems, Inc.
+#
+
+# Default cube-update.sys service configuration
+
+# The directory where the service process stores data.
+#     The /etc/cube-update directory is hard-coded as the
+#     location for the configuration files.  If it is
+#     writable, it can also be used as the location for
+#     the log file and information about the running
+#     service process.
+SERVER_DIR=/etc/cube-update
+
+SERVER_PID_FILE=pid
+SERVER_LOG_FILE=log
+SERVER_PENDING=pending
+SERVER_START_TIME_FILE=startup
+
+# Time in seconds between polls.
+#     Note that there is no attempt to align this on a "natural" time
+#     boundary, nor to account for load-based skew.  This is the time
+#     between the end of a poll and the beginning of the next poll.
+#     The default value is a little less than a week.  For many
+#     environments, this should be reduced in order to pick up security
+#     updates more promptly.
+POLLING_FREQUENCY=600000
+
+# Install updates automatically
+#     Options are "true" or "false" (command to execute).
+#     If true, the service automatically downloads and installs
+#         all available updates.
+#     If false, the service automatically checks for updates, but
+#         does not install them without manual intervention.  The
+#	  fact that updates are available is put in /etc/motd.
+SERVER_AUTO_UPDATE=false
+
+SERVER_UPDATE_COMMAND="/opt/overc-system-agent/overc host upgrade"

--- a/recipes-connectivity/cube-update/cube-update/cube-update.service
+++ b/recipes-connectivity/cube-update/cube-update/cube-update.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=SmartPM update daemon
+
+[Service]
+Type=forking
+PIDFile=/etc/cube-update/pid
+ExecStart=/etc/cube-update/cubeupdated start
+ExecReload=/etc/cube-update/cubeupdated restart
+ExecStop=/etc/cube-update/cubeupdated stop
+Restart=always
+RestartSec=600
+WatchdogSec=2419200
+StandardOutput=syslog
+DefaultDependencies=no
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-connectivity/cube-update/cube-update/cubepkgcheck
+++ b/recipes-connectivity/cube-update/cube-update/cubepkgcheck
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# Copyright (C) 2015 Wind River Systems, Inc.
+#
+
+smart update
+pkglist=`smart newer | awk '$NF ~ /^[0-9]+$/ { print $1 }'`
+if [ "$pkglist" != '' ]; then
+    touch /etc/motd
+    grep -v '^CUBEUPDATE: ' /etc/motd > /tmp/$$.motd
+    echo 'CUBEUPDATE: ' >> /tmp/$$.motd
+    echo 'CUBEUPDATE: NOTICE: Updates are available' >> /tmp/$$.motd
+    echo "CUBEUPDATE: $pkglist" >> /tmp/$$.motd
+    echo 'CUBEUPDATE: ' >> /tmp/$$.motd
+    mv /tmp/$$.motd /etc/motd
+fi

--- a/recipes-connectivity/cube-update/cube-update/cubeupdated
+++ b/recipes-connectivity/cube-update/cube-update/cubeupdated
@@ -1,0 +1,139 @@
+#!/bin/bash
+#
+# Copyright (C) 2015 Wind River Systems, Inc.
+#
+
+### BEGIN INIT INFO
+# Provides:             cube-update.sys
+# Required-Start:
+# Required-Stop:
+# Default-Start:        2 3 4 5
+# Default-Stop:         0 1 6
+# Short-Description:    automated system udpate service
+### END INIT INFO
+
+# set -e
+
+test -x /opt/overc-system-agent/overc || exit 0
+
+if [ -z "${SMARTPM_DIR}" ]; then
+    SMARTPM_DIR=/etc/cube-update
+fi
+
+test -x "${SMARTPM_DIR}/config.default" && source "${SMARTPM_DIR}/config.default"
+test -x "${SMARTPM_DIR}/config.local" && source "${SMARTPM_DIR}/config.local"
+
+function cube-update_service_is_running() {
+    if [ -f "${SERVER_DIR}/${SERVER_PID_FILE}" ]; then
+        PID=`cat "${SERVER_DIR}/${SERVER_PID_FILE}"`
+        if kill -0 "$PID" >/dev/null 2>&1 ; then
+            return 0
+        else
+            rm -f "${SERVER_DIR}/${SERVER_PID_FILE}"
+            return 1
+        fi
+    else
+        return 1
+    fi
+}
+
+function start_cube-update_service() {
+    if cube-update_service_is_running ; then
+        echo "system update server $PID already running"
+        exit 0
+    fi
+    touch "${SERVER_DIR}/${SERVER_PENDING}"
+    date '+%Y%m%d%H%M%S' > "${SERVER_DIR}/${SERVER_START_TIME_FILE}"
+    #
+    #  Note that using parenthesis to create a sub-shell does not work
+    #  in this context.  The child needs to save its pid for future
+    #  stop operations, but '$$' is not expanded appropriately when
+    #  using parenthesis.  So explicitly fork a sub-shell to handle it.
+    #
+    #  Note that the outer double quote allows variable expansion, and
+    #  because it is surrounded by the double quotes, single quotes inside
+    #  do not prevent variable expansion.  So any variables that should
+    #  not be expanded must be flagged by escaping the dollar sign with
+    #  a backslash as if they were only surrounded by double quotes.
+    #
+    bash -c "                                                                                   \
+        echo \$\$ > '${SERVER_DIR}/${SERVER_PID_FILE}' ;                                        \
+        rm '${SERVER_DIR}/${SERVER_PENDING}' ;                                                  \
+        while true ; do                                                                         \
+            test -x '${SMARTPM_DIR}/config.default' && source '${SMARTPM_DIR}/config.default' ; \
+            test -x '${SMARTPM_DIR}/config.local' && source '${SMARTPM_DIR}/config.local' ;     \
+            if ${SERVER_AUTO_UPDATE} ; then                                                     \
+                eval ${SERVER_UPDATE_COMMAND} ;                                                 \
+	    else                                                                                \
+		${SMARTPM_DIR}/cubepkgcheck ;                                                   \
+            fi ;                                                                                \
+            sleep ${POLLING_FREQUENCY} ;                                                        \
+        done                                                                                    \
+        " >> ${SERVER_DIR}/${SERVER_LOG_FILE} 2>&1 &
+
+    # Wait for the daemon to start
+    timeout=10
+    while [ -f "${SERVER_DIR}/${SERVER_PENDING}" ]; do
+        sleep 1
+	timeout=`expr $timeout - 1`
+	if [ "${timeout}" -le 0 ]; then
+	    break
+	fi
+    done
+}
+
+function stop_cube-update_service() {
+    if ! cube-update_service_is_running ; then
+        echo "system update server is not running"
+        exit 0
+    fi
+    PID=`cat "${SERVER_DIR}/${SERVER_PID_FILE}"`
+    if ! kill $PID ; then
+        if ! kill -3 $PID ; then
+            if ! kill -9 $PID ; then
+                echo "system update: Cannot stop service"
+            fi
+        fi
+    fi
+    rm -f "${SERVER_DIR}/${SERVER_PID_FILE}"
+    rm -f "${SERVER_DIR}/${SERVER_PENDING}"
+    rm -f "${SERVER_DIR}/${SERVER_START_TIME_FILE}"
+}
+
+function restart_cube-update_service() {
+    stop_cube-update_service
+    sleep 1
+    start_cube-update_service
+}
+
+function show_cube-update_service_status() {
+    if cube-update_service_is_running ; then
+        STARTED=0
+        if [ -f "${SERVER_DIR}/${SERVER_START_TIME_FILE}" ]; then
+            STARTED=`sed -e 's/\(....\)\(..\)\(..\)\(..\)\(..\)\(..\)/\1 \2 \3 \4:\5:\6/' "${SERVER_DIR}/${SERVER_START_TIME_FILE}"`
+        fi
+        echo "system update server $PID started at ${STARTED} with ${POLLING_FREQUENCY} frequency"
+    else
+        echo "system update server is not running" || true
+    fi
+}
+
+case "$1" in
+    start)
+        start_cube-update_service
+        ;;
+    stop)
+        stop_cube-update_service
+        ;;
+    reload|force-reload|restart|try-restart)
+        restart_cube-update_service
+        ;;
+    status)
+        show_cube-update_service_status
+        ;;
+    *)
+        echo "Usage: /etc/init.d/cube-update.sys {start|stop|restart|status}" || true
+        ;;
+esac
+
+exit 0

--- a/recipes-connectivity/cube-update/cube-update_1.0.bb
+++ b/recipes-connectivity/cube-update/cube-update_1.0.bb
@@ -1,0 +1,55 @@
+#
+# Copyright (C) 2015 Wind River Systems, Inc.
+#
+
+SUMMARY = "Service to update packages automatically"
+DESCRIPTION = "Service to update RPM packages periodically, \
+based on the overc host update command, and integrated with \
+the systemd and sysvinit init systems."
+
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6"
+RDEPENDS_${PN} = "python-smartpm"
+
+SRC_URI += " \
+	file://cubeupdated \
+	file://cubepkgcheck \
+	file://cube-update.service \
+	file://config.default \
+	"
+
+inherit autotools update-rc.d systemd
+
+FILES_${PN} += " \
+	${sysconfdir}/cube-update/* \
+	${sysconfdir}/init.d/* \
+	${systemd_unitdir}/system/* \
+	"
+
+SYSTEMD_SERVICE_${PN} = "cube-update.service"
+CONFFILES_${PN} = "${sysconfdir}/cube-update/config.default"
+SYSTEMD_AUTO_ENABLE = "${@base_contains('PULSAR_UNATTENDED_UPGRADE','true','enable','disable', d)}"
+
+INITSCRIPT_NAME = "cubeupdated"
+INITSCRIPT_PARAMS = "start 49 2 3 4 5 . stop 51 0 1 6 ."
+
+do_compile[noexec] = "1"
+
+do_install () {
+	# cube-update service:
+	install -d -m 0755 ${D}${sysconfdir}/cube-update
+	install -m 0555 ${WORKDIR}/config.default ${D}${sysconfdir}/cube-update/config.default
+	install -m 0555 ${WORKDIR}/cubeupdated ${D}${sysconfdir}/cube-update/cubeupdated
+	install -m 0555 ${WORKDIR}/cubepkgcheck ${D}${sysconfdir}/cube-update/cubepkgcheck
+
+	if ${@base_contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)}; then
+	    # systemd:
+	    install -d -m 0755 ${D}${systemd_unitdir}/system
+	    install -d -m 0755 ${D}${systemd_unitdir}/system/multi-user.target.wants
+	    install -m 0644 ${WORKDIR}/cube-update.service ${D}${systemd_unitdir}/system/cube-update.service
+	else
+	    # sysvinit:
+	    install -d -m 0755 ${D}${sysconfdir}/init.d
+	    install -m 0555 ${WORKDIR}/cubeupdated ${D}${sysconfdir}/init.d/cubeupdated
+	fi
+}


### PR DESCRIPTION
Create a system service, which polls the smart repositories for
system updates.  At runtime, configuration can be specified in
the file /etc/sysupdate/config.local to override the default
configuration specified in /etc/sysupdate/config.default.

By default, the update occurs slightly more frequently than once
per week.

The initial implementation:

- Does allow configuration of the behavior, among three choices:

	* not run (default)
	* check for updates, and notify via /etc/motd
	* auto install : download and install everything without
	  user interaction

    Note that another option, cron-driven, is possible.  This
	can be done by manually disabling the service and manually
	adding a cron job.

- Does allow runtime configuration of the polling period.

- Does allow the configuration directory to be changed.  However,
if this is done, it must be done in the sysupdate config file
and the systemd config file if systemd is used, to be effective.

- Implements both systemd and sysvinit installation recipes,
but only systemd was significantly tested.

- Does log to a file, but does not handle log rotation.

- Does not install the service automatically, unless configured
in local.conf at build time.  The docs need to be updated with
instructions on how to do this.

- Does not make any attempt to syncronize the poll to a particular
time of day.  If this is desired, the updates can be done from
cron.  The docs need to be updated with instructions on how to
do this.

- Does not make any attempt to correct for skew caused by the
duration of the poll itself.

- Does not check whether smartpm has been configured with valid
channels.

It is expected that the deficiencies among the points listed
above will be cleaned up at an appropriate future time.

Signed-off-by: T.O. Radzy Radzykewycz <radzy@windriver.com>