### PR TITLE
pkgconfig-native: work around the build failure with gcc >=6.0

### DIFF
--- a/recipes-core/glib-2.0/glib-2.0_2.44.1.bbappend
+++ b/recipes-core/glib-2.0/glib-2.0_2.44.1.bbappend
@@ -1,0 +1,1 @@
+EXTRA_OEMAKE_class-native += 'CFLAGS="${CFLAGS} -Wformat"'

--- a/recipes-devtools/elfutils/elfutils/0001-Remove-redundant-NULL-tests.patch
+++ b/recipes-devtools/elfutils/elfutils/0001-Remove-redundant-NULL-tests.patch
@@ -1,0 +1,171 @@
+From 03f6e96dcd28e13c3e95f4ba8d3652d3d4c7e198 Mon Sep 17 00:00:00 2001
+From: Lans Zhang <jia.zhang@windriver.com>
+Date: Wed, 9 Nov 2016 09:53:10 +0800
+Subject: [PATCH] Remove redundant NULL tests.
+
+GCC6 and Clang give warnings on redundant NULL tests of parameters
+that are declared with __nonnull_attribute__.
+
+Signed-off-by: Chih-Hung Hsieh <chh@google.com>
+Signed-off-by: Mark Wielaard <mjw@redhat.com>
+Signed-off-by: Lans Zhang <jia.zhang@windriver.com>
+---
+ libdw/dwarf_macro_getsrcfiles.c |  4 +---
+ libdw/dwarf_siblingof.c         |  3 +--
+ libdw/libdw_visit_scopes.c      | 14 ++++++--------
+ libdwfl/dwfl_frame.c            |  3 ++-
+ libdwfl/libdwfl.h               |  2 +-
+ libebl/ebldwarftoregno.c        |  3 +--
+ libebl/eblinitreg.c             |  3 ++-
+ libebl/eblnormalizepc.c         |  3 ++-
+ libebl/eblunwind.c              |  3 ++-
+ 9 files changed, 18 insertions(+), 20 deletions(-)
+
+diff --git a/libdw/dwarf_macro_getsrcfiles.c b/libdw/dwarf_macro_getsrcfiles.c
+index cc19043..3b1794b 100644
+--- a/libdw/dwarf_macro_getsrcfiles.c
++++ b/libdw/dwarf_macro_getsrcfiles.c
+@@ -36,9 +36,7 @@ int
+ dwarf_macro_getsrcfiles (Dwarf *dbg, Dwarf_Macro *macro,
+ 			 Dwarf_Files **files, size_t *nfiles)
+ {
+-  if (macro == NULL)
+-    return -1;
+-
++  /* macro is declared NN */
+   Dwarf_Macro_Op_Table *const table = macro->table;
+   if (table->files == NULL)
+     {
+diff --git a/libdw/dwarf_siblingof.c b/libdw/dwarf_siblingof.c
+index e598ae4..0dafc17 100644
+--- a/libdw/dwarf_siblingof.c
++++ b/libdw/dwarf_siblingof.c
+@@ -45,8 +45,7 @@ dwarf_siblingof (die, result)
+   if (die == NULL)
+     return -1;
+ 
+-  if (result == NULL)
+-    return -1;
++  /* result is declared NN */
+ 
+   if (result != die)
+     result->addr = NULL;
+diff --git a/libdw/libdw_visit_scopes.c b/libdw/libdw_visit_scopes.c
+index ac7e853..d0b5134 100644
+--- a/libdw/libdw_visit_scopes.c
++++ b/libdw/libdw_visit_scopes.c
+@@ -138,24 +138,22 @@ __libdw_visit_scopes (depth, root, imports, previsit, postvisit, arg)
+ 
+ 	child.prune = false;
+ 
+-	if (previsit != NULL)
+-	  {
+-	    int result = (*previsit) (depth + 1, &child, arg);
+-	    if (result != DWARF_CB_OK)
+-	      return result;
+-	  }
++	/* previsit is declared NN */
++	int result = (*previsit) (depth + 1, &child, arg);
++	if (result != DWARF_CB_OK)
++	  return result;
+ 
+ 	if (!child.prune && may_have_scopes (&child.die)
+ 	    && INTUSE(dwarf_haschildren) (&child.die))
+ 	  {
+-	    int result = recurse ();
++	    result = recurse ();
+ 	    if (result != DWARF_CB_OK)
+ 	      return result;
+ 	  }
+ 
+ 	if (postvisit != NULL)
+ 	  {
+-	    int result = (*postvisit) (depth + 1, &child, arg);
++	    result = (*postvisit) (depth + 1, &child, arg);
+ 	    if (result != DWARF_CB_OK)
+ 	      return result;
+ 	  }
+diff --git a/libdwfl/dwfl_frame.c b/libdwfl/dwfl_frame.c
+index f6f86c0..a91a1d6 100644
+--- a/libdwfl/dwfl_frame.c
++++ b/libdwfl/dwfl_frame.c
+@@ -143,7 +143,8 @@ dwfl_attach_state (Dwfl *dwfl, Elf *elf, pid_t pid,
+ 
+   /* Reset any previous error, we are just going to try again.  */
+   dwfl->attacherr = DWFL_E_NOERROR;
+-  if (thread_callbacks == NULL || thread_callbacks->next_thread == NULL
++  /* thread_callbacks is declared NN */
++  if (thread_callbacks->next_thread == NULL
+       || thread_callbacks->set_initial_registers == NULL)
+     {
+       dwfl->attacherr = DWFL_E_INVALID_ARGUMENT;
+diff --git a/libdwfl/libdwfl.h b/libdwfl/libdwfl.h
+index 2bb4f45..bf7cb82 100644
+--- a/libdwfl/libdwfl.h
++++ b/libdwfl/libdwfl.h
+@@ -421,7 +421,7 @@ extern int dwfl_validate_address (Dwfl *dwfl,
+    with the difference between addresses within the loaded module
+    and those in symbol tables or Dwarf information referring to it.  */
+ extern Elf *dwfl_module_getelf (Dwfl_Module *, GElf_Addr *bias)
+-  __nonnull_attribute__ (1, 2);
++  __nonnull_attribute__ (2);
+ 
+ /* Return the number of symbols in the module's symbol table,
+    or -1 for errors.  */
+diff --git a/libebl/ebldwarftoregno.c b/libebl/ebldwarftoregno.c
+index 8fb8540..c664496 100644
+--- a/libebl/ebldwarftoregno.c
++++ b/libebl/ebldwarftoregno.c
+@@ -35,7 +35,6 @@
+ bool
+ ebl_dwarf_to_regno (Ebl *ebl, unsigned *regno)
+ {
+-  if (ebl == NULL)
+-    return false;
++  /* ebl is declared NN */
+   return ebl->dwarf_to_regno == NULL ? true : ebl->dwarf_to_regno (ebl, regno);
+ }
+diff --git a/libebl/eblinitreg.c b/libebl/eblinitreg.c
+index ca681c0..a76bed0 100644
+--- a/libebl/eblinitreg.c
++++ b/libebl/eblinitreg.c
+@@ -47,7 +47,8 @@ ebl_set_initial_registers_tid (Ebl *ebl, pid_t tid,
+ size_t
+ ebl_frame_nregs (Ebl *ebl)
+ {
+-  return ebl == NULL ? 0 : ebl->frame_nregs;
++  /* ebl is declared NN */
++  return ebl->frame_nregs;
+ }
+ 
+ GElf_Addr
+diff --git a/libebl/eblnormalizepc.c b/libebl/eblnormalizepc.c
+index a5fea77..1629353 100644
+--- a/libebl/eblnormalizepc.c
++++ b/libebl/eblnormalizepc.c
+@@ -35,6 +35,7 @@
+ void
+ ebl_normalize_pc (Ebl *ebl, Dwarf_Addr *pc)
+ {
+-  if (ebl != NULL && ebl->normalize_pc != NULL)
++  /* ebl is declared NN */
++  if (ebl->normalize_pc != NULL)
+     ebl->normalize_pc (ebl, pc);
+ }
+diff --git a/libebl/eblunwind.c b/libebl/eblunwind.c
+index 1251c1b..2970d03 100644
+--- a/libebl/eblunwind.c
++++ b/libebl/eblunwind.c
+@@ -37,7 +37,8 @@ ebl_unwind (Ebl *ebl, Dwarf_Addr pc, ebl_tid_registers_t *setfunc,
+ 	    ebl_tid_registers_get_t *getfunc, ebl_pid_memory_read_t *readfunc,
+ 	    void *arg, bool *signal_framep)
+ {
+-  if (ebl == NULL || ebl->unwind == NULL)
++  /* ebl is declared NN */
++  if (ebl->unwind == NULL)
+     return false;
+   return ebl->unwind (ebl, pc, setfunc, getfunc, readfunc, arg, signal_framep);
+ }
+-- 
+2.7.4
+

--- a/recipes-devtools/elfutils/elfutils/0001-libebl-Fix-missing-brackets-around-if-statement-body.patch
+++ b/recipes-devtools/elfutils/elfutils/0001-libebl-Fix-missing-brackets-around-if-statement-body.patch
@@ -1,0 +1,60 @@
+From 0eb05d768de1c26c3b2dab9fe1166ec23c91408c Mon Sep 17 00:00:00 2001
+From: Lans Zhang <jia.zhang@windriver.com>
+Date: Wed, 9 Nov 2016 09:41:17 +0800
+Subject: [PATCH] libebl: Fix missing brackets around if statement body.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+GCC6 [will have] a nice new warning that showed a real bug:
+
+elfutils/libebl/eblobjnote.c: In function ‘ebl_object_note’:
+elfutils/libebl/eblobjnote.c:135:5: error: statement is indented as if
+it were guarded by... [-Werror=misleading-indentation]
+     switch (type)
+     ^~~~~~
+
+elfutils/libebl/eblobjnote.c:45:3: note: ...this ‘if’ clause, but it is
+not
+   if (! ebl->object_note (name, type, descsz, desc))
+   ^~
+
+And indeed, it should have been under the if, but wasn't because of
+missing
+brackets. Added brackets (and reindent).
+
+Signed-off-by: Mark Wielaard <mjw@redhat.com>
+Signed-off-by: Lans Zhang <jia.zhang@windriver.com>
+---
+ libebl/eblobjnote.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/libebl/eblobjnote.c b/libebl/eblobjnote.c
+index b9bf1c0..986040d 100644
+--- a/libebl/eblobjnote.c
++++ b/libebl/eblobjnote.c
+@@ -1,5 +1,5 @@
+ /* Print contents of object file note.
+-   Copyright (C) 2002, 2007, 2009, 2011, 2015 Red Hat, Inc.
++   Copyright (C) 2002, 2007, 2009, 2011, 2015, 2016 Red Hat, Inc.
+    This file is part of elfutils.
+    Written by Ulrich Drepper <drepper@redhat.com>, 2002.
+ 
+@@ -46,7 +46,7 @@ ebl_object_note (ebl, name, type, descsz, desc)
+      uint32_t descsz;
+      const char *desc;
+ {
+-  if (! ebl->object_note (name, type, descsz, desc))
++  if (! ebl->object_note (name, type, descsz, desc)) {
+     /* The machine specific function did not know this type.  */
+ 
+     if (strcmp ("stapsdt", name) == 0)
+@@ -232,4 +232,5 @@ ebl_object_note (ebl, name, type, descsz, desc)
+ 	/* Unknown type.  */
+ 	break;
+       }
++   }
+ }
+-- 
+2.7.4
+

--- a/recipes-devtools/elfutils/elfutils_0.163.bbappend
+++ b/recipes-devtools/elfutils/elfutils_0.163.bbappend
@@ -1,0 +1,6 @@
+FILESPATH_append := ":${@base_set_filespath(['${THISDIR}'], d)}/${PN}"
+
+SRC_URI += " \
+    file://0001-libebl-Fix-missing-brackets-around-if-statement-body.patch \
+    file://0001-Remove-redundant-NULL-tests.patch \
+"

--- a/recipes-devtools/pkgconfig/pkgconfig_git.bbappend
+++ b/recipes-devtools/pkgconfig/pkgconfig_git.bbappend
@@ -1,0 +1,1 @@
+EXTRA_OEMAKE_class-native += 'CFLAGS="${CFLAGS} -Wformat"'


### PR DESCRIPTION
The following commits resolve the host build failure on Fedora 24 with GCC6.