### PR TITLE
Bug fixes for supporting GCC 6

### DIFF
--- a/recipes-devtools/openjade/openjade-native_1.3.2.bbappend
+++ b/recipes-devtools/openjade/openjade-native_1.3.2.bbappend
@@ -1,0 +1,1 @@
+CXXFLAGS += "-fno-tree-dse"


### PR DESCRIPTION
- openjade-native: backported from oe-core
