### PR TITLE
Clean up essential-only package groups

### DIFF
--- a/templates/default/template.conf
+++ b/templates/default/template.conf
@@ -53,11 +53,52 @@ EXTRA_X86_BOOT_intel-corei7-64 = "grub-efi"
 
 # HAC and extras
 EXTRA_HAC_SW += "hac haccmds essential-cfg-mgr"
-CUBE_DOM_SERVER_EXTRA_INSTALL += "${EXTRA_HAC_SW} ${CUBE_GW_EXTRAS}"
-CUBE_DOM_E_EXTRA_INSTALL += "${EXTRA_HAC_SW} ${CUBE_GW_EXTRAS} ${EXTRA_WIFI_SW} ${EXTRA_MULTILIB}"
-CUBE_DOM_GW_EXTRA_INSTALL += "${EXTRA_HAC_SW} ${CUBE_GW_EXTRAS}"
-CUBE_DOM_GW_GFX_EXTRA_INSTALL += "${EXTRA_HAC_SW} ${CUBE_GW_EXTRAS}"
-CUBE_ESSENTIAL_EXTRA_INSTALL_append += "pulsar-upgrade-mgr ${EXTRA_X86_BOOT}"
+
+CUBE_DOM_SERVER_EXTRA_INSTALL += " \
+    ${EXTRA_HAC_SW} \
+    ${CUBE_GW_EXTRAS} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'ima', 'packagegroup-ima', '', d)} \
+"
+CUBE_DOM_E_EXTRA_INSTALL += " \
+    ${EXTRA_HAC_SW} \
+    ${CUBE_GW_EXTRAS} \
+    ${EXTRA_WIFI_SW} \
+    ${EXTRA_MULTILIB} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'ima', 'packagegroup-ima', '', d)} \
+"
+CUBE_DOM_GW_EXTRA_INSTALL += " \
+    ${EXTRA_HAC_SW} \
+    ${CUBE_GW_EXTRAS} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'ima', 'packagegroup-ima', '', d)} \
+"
+CUBE_DOM_GW_GFX_EXTRA_INSTALL += " \
+    ${EXTRA_HAC_SW} \
+    ${CUBE_GW_EXTRAS} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'ima', 'packagegroup-ima', '', d)} \
+"
+CUBE_ESSENTIAL_EXTRA_INSTALL += " \
+    pulsar-upgrade-mgr \
+    ${EXTRA_X86_BOOT} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'uefi-secure-boot', 'packagegroup-uefi-secure-boot', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'mok-secure-boot', 'packagegroup-mok-secure-boot', '', d)} \
+    ${@bb.utils.contains('MACHINE_FEATURES', 'tpm', 'packagegroup-tpm', '', d)} \
+    ${@bb.utils.contains('MACHINE_FEATURES', 'tpm2', 'packagegroup-tpm2', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'storage-encryption', 'packagegroup-storage-encryption', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'ima', 'packagegroup-ima', '', d)} \
+"
+CUBE_DOM_0_EXTRA_INSTALL += " \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'ima', 'packagegroup-ima', '', d)} \
+"
+CUBE_DOM_1_EXTRA_INSTALL += " \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'ima', 'packagegroup-ima', '', d)} \
+"
+CUBE_BUILDER_EXTRA_INSTALL += " \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'ima', 'packagegroup-ima', '', d)} \
+"
+ROOTFS_BOOTSTRAP_INSTALL += " \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'storage-encryption', 'packagegroup-storage-encryption-initramfs', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'ima', 'packagegroup-ima-initramfs', '', d)} \
+"
 
 ZYNQ_QEMU = ""
 ZYNQ_QEMU_xilinx-zynq = "qemu-xilinx-native"


### PR DESCRIPTION
All essential-only package groups will be conditionally installed if the
corresponding DISTRO_FEATURES/MACHINE_FEATURES is defined.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>