### PR TITLE
cube-builder-initramfs: use ROOTFS_BOOTSTRAP_INSTALL_append to add th…

### DIFF
--- a/templates/default/template.conf
+++ b/templates/default/template.conf
@@ -95,7 +95,7 @@ CUBE_DOM_1_EXTRA_INSTALL += " \
 CUBE_BUILDER_EXTRA_INSTALL += " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'ima', 'packagegroup-ima', '', d)} \
 "
-ROOTFS_BOOTSTRAP_INSTALL += " \
+ROOTFS_BOOTSTRAP_INSTALL_append = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'storage-encryption', 'packagegroup-storage-encryption-initramfs', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'ima', 'packagegroup-ima-initramfs', '', d)} \
 "


### PR DESCRIPTION
…e necessary packages

_append is never overwritten by the set operation (=). Otherwise, the
set operation originated from image.bbclass will reset the resulting
ROOTFS_BOOTSTRAP_INSTALL.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>