### PR TITLE
cube-builder-initramfs: use CUBE_BUILDER_INITRAMFS_EXTRA_INSTALL to add extra packages

### DIFF
--- a/templates/default/template.conf
+++ b/templates/default/template.conf
@@ -95,7 +95,7 @@ CUBE_DOM_1_EXTRA_INSTALL += " \
 CUBE_BUILDER_EXTRA_INSTALL += " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'ima', 'packagegroup-ima', '', d)} \
 "
-ROOTFS_BOOTSTRAP_INSTALL_append = " \
+CUBE_BUILDER_INITRAMFS_EXTRA_INSTALL += " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'storage-encryption', 'packagegroup-storage-encryption-initramfs', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'ima', 'packagegroup-ima-initramfs', '', d)} \
 "


### PR DESCRIPTION

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>