### PR TITLE
Define the initramfs globally for x86 machines

### DIFF
--- a/templates/default/template.conf
+++ b/templates/default/template.conf
@@ -35,6 +35,9 @@ INHERIT_DISTRO = " debian devshell sstate license package-name"
 #force override the distro name
 DISTRO_NAME_forcevariable = "Pulsar Linux"
 
+INITRAMFS_IMAGE_x86 = "cube-builder-initramfs"
+INITRAMFS_IMAGE_x86-64 = "cube-builder-initramfs"
+
 # Extra software for the Gateway layers
 CUBE_GW_EXTRAS = "gps-utils gpsd"
 
@@ -49,7 +52,13 @@ rtl8723bs \
 EXTRA_MULTILIB_intel-corei7-64 = "lib32-glib-2.0"
 
 EXTRA_X86_BOOT = ""
-EXTRA_X86_BOOT_intel-corei7-64 = "grub-efi"
+EXTRA_X86_BOOT_x86 = " \
+    ${@'kernel-initramfs-image' if d.getVar('INITRAMFS_IMAGE', True) and d.getVar('INITRAMFS_IMAGE_BUNDLE', True) else ''} \
+"
+EXTRA_X86_BOOT_x86-64 = " \
+    grub-efi \
+    ${@'kernel-initramfs-image' if d.getVar('INITRAMFS_IMAGE', True) and d.getVar('INITRAMFS_IMAGE_BUNDLE', True) else ''} \
+"
 
 # HAC and extras
 EXTRA_HAC_SW += "hac haccmds essential-cfg-mgr"


### PR DESCRIPTION
initramfs needs to be defined globally to allow to do_bundle_initramfs()
during the kernel build.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>