### PR TITLE
wrlabs: define CUBE_COMMON_INSTALL for the installation on all cubes

### DIFF
--- a/templates/default/template.conf
+++ b/templates/default/template.conf
@@ -40,6 +40,12 @@ INITRAMFS_IMAGE_x86-64 = "cube-builder-initramfs"
 
 CUBE_GW_EXTRAS ?= ""
 
+# Common installation *except* initramfs image
+CUBE_COMMON_INSTALL = " \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'ima', 'packagegroup-ima', '', d)} \
+    key-store-rpm-pubkey \
+"
+
 EXTRA_WIFI_SW += " \
 hostapd \
 hostap-utils \
@@ -63,28 +69,29 @@ EXTRA_X86_BOOT_x86-64 = " \
 EXTRA_HAC_SW += "hac haccmds essential-cfg-mgr"
 
 CUBE_DOM_SERVER_EXTRA_INSTALL += " \
+    ${CUBE_COMMON_INSTALL} \
     ${EXTRA_HAC_SW} \
     ${CUBE_GW_EXTRAS} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'ima', 'packagegroup-ima', '', d)} \
 "
 CUBE_DOM_E_EXTRA_INSTALL += " \
+    ${CUBE_COMMON_INSTALL} \
     ${EXTRA_HAC_SW} \
     ${CUBE_GW_EXTRAS} \
     ${EXTRA_WIFI_SW} \
     ${EXTRA_MULTILIB} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'ima', 'packagegroup-ima', '', d)} \
 "
 CUBE_DOM_GW_EXTRA_INSTALL += " \
+    ${CUBE_COMMON_INSTALL} \
     ${EXTRA_HAC_SW} \
     ${CUBE_GW_EXTRAS} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'ima', 'packagegroup-ima', '', d)} \
 "
 CUBE_DOM_GW_GFX_EXTRA_INSTALL += " \
+    ${CUBE_COMMON_INSTALL} \
     ${EXTRA_HAC_SW} \
     ${CUBE_GW_EXTRAS} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'ima', 'packagegroup-ima', '', d)} \
 "
 CUBE_ESSENTIAL_EXTRA_INSTALL += " \
+    ${CUBE_COMMON_INSTALL} \
     pulsar-upgrade-mgr \
     ${EXTRA_X86_BOOT} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'uefi-secure-boot', 'packagegroup-uefi-secure-boot', '', d)} \
@@ -92,16 +99,15 @@ CUBE_ESSENTIAL_EXTRA_INSTALL += " \
     ${@bb.utils.contains('MACHINE_FEATURES', 'tpm', 'packagegroup-tpm', '', d)} \
     ${@bb.utils.contains('MACHINE_FEATURES', 'tpm2', 'packagegroup-tpm2', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'storage-encryption', 'packagegroup-storage-encryption', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'ima', 'packagegroup-ima', '', d)} \
 "
 CUBE_DOM_0_EXTRA_INSTALL += " \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'ima', 'packagegroup-ima', '', d)} \
+    ${CUBE_COMMON_INSTALL} \
 "
 CUBE_DOM_1_EXTRA_INSTALL += " \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'ima', 'packagegroup-ima', '', d)} \
+    ${CUBE_COMMON_INSTALL} \
 "
 CUBE_BUILDER_EXTRA_INSTALL += " \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'ima', 'packagegroup-ima', '', d)} \
+    ${CUBE_COMMON_INSTALL} \
 "
 CUBE_BUILDER_INITRAMFS_EXTRA_INSTALL += " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'storage-encryption', 'packagegroup-storage-encryption-initramfs', '', d)} \


### PR DESCRIPTION
Note only initramfs image is not included.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>