### PR TITLE
wrlab: install kernel-initramfs-image as long as initramfs used

### DIFF
--- a/templates/default/template.conf
+++ b/templates/default/template.conf
@@ -58,11 +58,11 @@ EXTRA_MULTILIB_intel-corei7-64 = "lib32-glib-2.0"
 
 EXTRA_X86_BOOT = ""
 EXTRA_X86_BOOT_x86 = " \
-    ${@'kernel-initramfs-image' if d.getVar('INITRAMFS_IMAGE', True) and d.getVar('INITRAMFS_IMAGE_BUNDLE', True) else ''} \
+    ${@'kernel-initramfs-image' if d.getVar('INITRAMFS_IMAGE', True) else ''} \
 "
 EXTRA_X86_BOOT_x86-64 = " \
     grub-efi \
-    ${@'kernel-initramfs-image' if d.getVar('INITRAMFS_IMAGE', True) and d.getVar('INITRAMFS_IMAGE_BUNDLE', True) else ''} \
+    ${@'kernel-initramfs-image' if d.getVar('INITRAMFS_IMAGE', True) else ''} \
 "
 
 # HAC and extras


### PR DESCRIPTION
kernel-initramfs-image provides the initramfs image and it should be
installed as long as initramfs is defined for a real rootfs image.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>