### PR TITLE
grub-efi: install the grub-installer.cfg for Pulsar Linux

### DIFF
--- a/recipes-bsp/grub/grub-efi/grub-runtime.cfg
+++ b/recipes-bsp/grub/grub-efi/grub-runtime.cfg
@@ -1,0 +1,26 @@
+set default="0"
+set timeout=3
+set color_normal='light-gray/black'
+set color_highlight='light-green/blue'
+
+insmod efivar
+get_efivar -f uint8 -s unprovisioned SetupMode
+
+if [ "${unprovisioned}" = "1" ]; then
+    set timeout=0
+
+    menuentry "Automatic Certificate Provision" {
+        chainloader ${prefix}/LockDown.efi
+    }
+fi
+
+menuentry "OverC" {
+    set fallback="OverC recovery"
+    linux /bzImage root=LABEL=OVERCROOTFS ro rootwait
+    initrd /initrd
+}
+
+menuentry "OverC recovery" {
+    linux /bzImage_bakup root=LABEL=OVERCROOTFS rootflags=subvol=rootfs_bakup ro rootwait
+    initrd /initrd
+}

--- a/recipes-bsp/grub/grub-efi_2.00.bbappend
+++ b/recipes-bsp/grub/grub-efi_2.00.bbappend
@@ -1,3 +1,12 @@
+#
+# Copyright (C) 2016-2017 Wind River Systems, Inc.
+#
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/grub-efi:"
+
+SRC_URI += " \
+    file://grub-runtime.cfg \
+"
 
 ALTERNATIVE_PRIORITY = "50"
 ALTERNATIVE_${PN} = "grub-editenv grub-fstest grub-menulst2cfg grub-mkimage \
@@ -17,3 +26,13 @@ ALTERNATIVE_TARGET[grub-bios-setup] = "${sbindir}/grub-bios-setup"
 ALTERNATIVE_TARGET[grub-ofpathname] = "${sbindir}/grub-ofpathname"
 ALTERNATIVE_TARGET[grub-probe] = "${sbindir}/grub-probe"
 ALTERNATIVE_TARGET[grub-install] = "${sbindir}/grub-install"
+
+do_install_append_class-target() {
+    install -m 0600 "${WORKDIR}/grub-runtime.cfg" "${D}${EFI_BOOT_PATH}/grub.cfg"
+}
+
+do_deploy_append_class-target() {
+    install -d ${DEPLOYDIR}
+
+    install -m 0600 "${D}${EFI_BOOT_PATH}/grub.cfg" "${DEPLOYDIR}/grub.cfg"
+}


### PR DESCRIPTION
The Pulsar Linux always provides a default grub config file for the installer
and the build system can sign it during the build progress.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>