### PR TITLE
grub-efi: set the fallback to entry number

### DIFF
--- a/recipes-bsp/grub/grub-efi/grub-runtime.cfg
+++ b/recipes-bsp/grub/grub-efi/grub-runtime.cfg
@@ -15,7 +15,7 @@ if [ "${unprovisioned}" = "1" ]; then
 fi
 
 menuentry "Pulsar Linux 8" {
-    set fallback="Pulsar Linux 8 recovery"
+    set fallback=1
     linux /bzImage root=LABEL=OVERCROOTFS ro rootwait
     initrd /initrd
 }


### PR DESCRIPTION
Current grub doesn't support to set the fallback to title.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>