### PR TITLE
wrlab: don't always install key-store-rpm-pubkey

### DIFF
--- a/templates/default/template.conf
+++ b/templates/default/template.conf
@@ -43,7 +43,6 @@ CUBE_GW_EXTRAS ?= ""
 # Common installation *except* initramfs image
 CUBE_COMMON_INSTALL = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'ima', 'packagegroup-ima', '', d)} \
-    ${@bb.utils.contains('BBFILE_COLLECTIONS','meta-secure-env','key-store-rpm-pubkey','',d)} \
 "
 
 EXTRA_WIFI_SW += " \


### PR DESCRIPTION
rpm-signing feature is not enabled by default with meta-secure-env.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>