### PR TITLE
grub-efi: fix do_deploy() failure if uefi-secure-boot is not configured

### DIFF
--- a/recipes-bsp/grub/grub-efi_2.00.bbappend
+++ b/recipes-bsp/grub/grub-efi_2.00.bbappend
@@ -34,7 +34,8 @@ do_install_append_class-target() {
 do_deploy_append_class-target() {
     install -d ${DEPLOYDIR}
 
-    install -m 0600 "${D}${EFI_BOOT_PATH}/grub.cfg" "${DEPLOYDIR}"
     [ -s "${D}${EFI_BOOT_PATH}/grub.cfg.p7b" ] &&
         install -m 0600 "${D}${EFI_BOOT_PATH}/grub.cfg.p7b" "${DEPLOYDIR}"
+
+    install -m 0600 "${D}${EFI_BOOT_PATH}/grub.cfg" "${DEPLOYDIR}"
 }


### PR DESCRIPTION
grub.cfg.p7b may not exist if uefi-secure-boot is not configured.
In this case, do_deploy() fails checking the return value set by
the condition statement. To fix this issue, just adjust the position
of the condition statement.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>