### PR TITLE
wrlabs-integration: integrate the templates for security features

### DIFF
--- a/templates/default/template.conf
+++ b/templates/default/template.conf
@@ -153,3 +153,6 @@ BB_HASHDEP_DISABLE = "1"
 
 # Use zeroconf to pickup avahi
 DISTRO_FEATURES_append = " zeroconf"
+
+RPM_GPG_NAME ??= ""
+RPM_GPG_PASSPHRASE ??= ""

--- a/templates/feature/efi-secure-boot/README
+++ b/templates/feature/efi-secure-boot/README
@@ -1,0 +1,7 @@
+EFI secure boot feature
+=======================
+
+This feature consists of two widely used secure boot technologies: UEFI Secure
+Boot and MOK Secure Boot.
+
+Details please refer to meta-efi-secure-boot/README.md.

--- a/templates/feature/efi-secure-boot/image.inc
+++ b/templates/feature/efi-secure-boot/image.inc
@@ -1,0 +1,5 @@
+#
+# Copyright (C) 2017 Wind River Systems, Inc.
+#
+
+IMAGE_INSTALL += "packagegroup-efi-secure-boot"

--- a/templates/feature/efi-secure-boot/template.conf
+++ b/templates/feature/efi-secure-boot/template.conf
@@ -1,0 +1,12 @@
+#
+# Copyright (C) 2016-2017 Wind River Systems, Inc.
+#
+
+MACHINE_FEATURES_append += "efi"
+MACHINE_FEATURES_NATIVE_append += "efi"
+
+DISTRO_FEATURES_append += "efi-secure-boot"
+DISTRO_FEATURES_NATIVE_append += "efi-secure-boot"
+
+# Enforce overwriting the grub filename for EFI boot
+GRUB_IMAGE = '${@bb.utils.contains("TARGET_ARCH", "x86_64", "grubx64.efi", "grubia32.efi", d)}'

--- a/templates/feature/encrypted-storage/README
+++ b/templates/feature/encrypted-storage/README
@@ -1,0 +1,8 @@
+Encrypted Storage
+=================
+
+This feature provides secure storage for application data. Some applications
+need secure storage for sensitive data which must not be accessible to another
+device.
+
+Details please refer to meta-encrypted-storage/README.md.

--- a/templates/feature/encrypted-storage/image.inc
+++ b/templates/feature/encrypted-storage/image.inc
@@ -1,0 +1,6 @@
+#
+# Copyright (C) 2017 Wind River Systems, Inc.
+#
+
+IMAGE_INSTALL_append += "packagegroup-encrypted-storage"
+IMAGE_INSTALL_INITRAMFS_append += "packagegroup-encrypted-storage-initramfs"

--- a/templates/feature/encrypted-storage/require
+++ b/templates/feature/encrypted-storage/require
@@ -1,0 +1,5 @@
+#
+# Copyright (C) 2017 Wind River Systems, Inc.
+#
+
+feature/tpm2

--- a/templates/feature/encrypted-storage/template.conf
+++ b/templates/feature/encrypted-storage/template.conf
@@ -1,0 +1,6 @@
+#
+# Copyright (C) 2016-2017 Wind River Systems, Inc.
+#
+
+DISTRO_FEATURES_append += "encrypted-storage"
+DISTRO_FEATURES_NATIVE_append += "encrypted-storage"

--- a/templates/feature/ima/README
+++ b/templates/feature/ima/README
@@ -1,0 +1,9 @@
+Integrity Measurement Architecture (IMA)
+========================================
+
+The Linux IMA subsystem introduces hooks within the Linux kernel to support
+measuring the integrity of files that are loaded (including application code)
+before it is executed or mmap()ed to memory. The measured value (hash) is then
+registered in a log that can be consulted by administrators.
+
+Details please refer to meta-integrity/README.md.

--- a/templates/feature/ima/image.inc
+++ b/templates/feature/ima/image.inc
@@ -1,0 +1,6 @@
+#
+# Copyright (C) 2017 Wind River Systems, Inc.
+#
+
+IMAGE_INSTALL_append += "packagegroup-ima"
+IMAGE_INSTALL_INITRAMFS_append += "packagegroup-ima-initramfs"

--- a/templates/feature/ima/require
+++ b/templates/feature/ima/require
@@ -1,0 +1,6 @@
+#
+# Copyright (C) 2017 Wind River Systems, Inc.
+#
+
+feature/tpm
+feature/tpm2

--- a/templates/feature/ima/template.conf
+++ b/templates/feature/ima/template.conf
@@ -1,0 +1,6 @@
+#
+# Copyright (C) 2016-2017 Wind River Systems, Inc.
+#
+
+DISTRO_FEATURES_append += "ima"
+DISTRO_FEATURES_NATIVE_append += "ima"

--- a/templates/feature/tpm/image.inc
+++ b/templates/feature/tpm/image.inc
@@ -1,0 +1,5 @@
+#
+# Copyright (C) 2017 Wind River Systems, Inc.
+#
+
+IMAGE_INSTALL_append += "packagegroup-tpm"

--- a/templates/feature/tpm/template.conf
+++ b/templates/feature/tpm/template.conf
@@ -1,0 +1,6 @@
+#
+# Copyright (C) 2016-2017 Wind River Systems, Inc.
+#
+
+DISTRO_FEATURES_append += "tpm"
+DISTRO_FEATURES_NATIVE_append += "tpm"

--- a/templates/feature/tpm2/README
+++ b/templates/feature/tpm2/README
@@ -1,0 +1,49 @@
+TPM 2.0
+=======
+
+This feature enables Trusted Platform Module (TPM 2.0) support, including 
+kernel option changes to enable tpm drivers, and picking up TPM 2.0 packages.
+
+Trusted Platform Module (TPM 2.0) is a microcontroller that stores keys,
+passwords, and digital certificates. A discrete TPM 2.0 offers the
+capabilities as part of the overall platform security requirements.
+
+TPM 2.0 packages
+================
+
+The following open-source packages are supported for TPM 2.0.
+
+tpm2.0-tss
+----------
+The TPM2.0-TSS library from Intel, which provides support for applications
+to utilize TPM 2.0 hardware. See README in package for more detailed
+information. Project homepage:
+    https://github.com/01org/TPM2.0-TSS
+
+Visit TCG official website for TSS 2.0 API specification.
+    http://www.trustedcomputinggroup.org
+
+tpm2.0-tools
+------------
+The TPM 2.0 tools from Intel, based on TPM2.0-TSS library, contains commands
+to manage and diagnose the TPM, and commands to utilize some of the
+capabilities available in the TPM. For how to use, the manual file in package
+is a good place to start. Project homepage:
+    https://github.com/01org/tpm2.0-tools
+
+Clear TPM
+=========
+
+For TPM 2.0, the following typical steps can be performed to get the TPM
+ready for use:
+
+1. Clear and enable TPM from the BIOS or set the security jumper on the board.
+
+2. Take TPM ownership, setting Owner/Endorsement/Lockout passwords if
+   necessary. These passwords are used for the authorization to certain
+   TPM 2.0 commands.
+
+     # tpm2_takeownership -o <ownerPasswd> -e <endorsePasswd> -l <lockPasswd>
+
+Then, you can use the TPM for a specific need, such as key generation,
+sealing encrypted data, etc.

--- a/templates/feature/tpm2/image.inc
+++ b/templates/feature/tpm2/image.inc
@@ -1,0 +1,6 @@
+#
+# Copyright (C) 2017 Wind River Systems, Inc.
+#
+
+IMAGE_INSTALL_append += "packagegroup-tpm2"
+IMAGE_INSTALL_INITRAMFS_append += "packagegroup-tpm2-initramfs"

--- a/templates/feature/tpm2/template.conf
+++ b/templates/feature/tpm2/template.conf
@@ -1,0 +1,6 @@
+#
+# Copyright (C) 2016-2017 Wind River Systems, Inc.
+#
+
+DISTRO_FEATURES_append += "tpm2"
+DISTRO_FEATURES_NATIVE_append += "tpm2"


### PR DESCRIPTION
All templates for security features are not maintained in the dedicated
security layer.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>