### PR TITLE
wrlab-integration: increase the layer priority

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -13,7 +13,7 @@ BBFILES := "${BBFILES} ${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "wrlabs-integration"
 BBFILE_PATTERN_wrlabs-integration := "^${LAYERDIR}/"
-BBFILE_PRIORITY_wrlabs-integration = "9"
+BBFILE_PRIORITY_wrlabs-integration = "20"
 
 # Common licenses used by some packages in this layer
 LICENSE_PATH += "${LAYERDIR}/files/common-licenses"


### PR DESCRIPTION
wrlab-integration is designed to overwrite some settings in higher prority
so set the priority to 20 over all other layers.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>