### PR TITLE
rpm: drop rpm_%.bbappend

### DIFF
--- a/recipes-devtools/rpm/rpm_%.bbappend
+++ b/recipes-devtools/rpm/rpm_%.bbappend
@@ -1,1 +1,0 @@
-PACKAGECONFIG[imaevm] = "--with-imaevm,,ima-evm-utils"


### PR DESCRIPTION
The latest oe-core has been synced up with the oe-core commit 9d7797e43 so
this bbappend for RPM file signing is not required any more.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>