### PR TITLE
feature/ima: inherit sign_rpm_ext

### DIFF
--- a/templates/feature/ima/template.conf
+++ b/templates/feature/ima/template.conf
@@ -4,3 +4,5 @@
 
 DISTRO_FEATURES_append += "ima"
 DISTRO_FEATURES_NATIVE_append += "ima"
+
+INHERIT += "sign_rpm_ext"


### PR DESCRIPTION
The same logic was removed in layer.conf from meta-integrity.

Signed-off-by: Jia Zhang <lans.zhang2008@gmail.com>