### PR TITLE
grub-efi: Do not overwrite signed grub efi bianry when secure boot is enabled

### DIFF
--- a/recipes-bsp/grub/grub-efi_2.02.bbappend
+++ b/recipes-bsp/grub/grub-efi_2.02.bbappend
@@ -50,13 +50,17 @@ do_install_append_class-target() {
 do_deploy_append_class-target() {
     install -d ${DEPLOYDIR}
 
-    [ -s "${D}${EFI_BOOT_PATH}/grub.cfg.p7b" ] &&
+    if [ "${@bb.utils.contains('DISTRO_FEATURES', 'efi-secure-boot', '1', '0', d)}" = "1" ]; then 
         install -m 0600 "${D}${EFI_BOOT_PATH}/grub.cfg.p7b" "${DEPLOYDIR}"
+    fi
 
     install -m 0600 "${D}${EFI_BOOT_PATH}/grub.cfg" "${DEPLOYDIR}"
    
     efi_target=`echo ${GRUB_IMAGE} | sed 's/^grub-efi-//'` 
-    install -m 644 ${B}/${GRUB_IMAGE} ${D}${EFI_BOOT_PATH}/${efi_target}
+
+    if [ "${@bb.utils.contains('DISTRO_FEATURES', 'efi-secure-boot', '1', '0', d)}" = "0" ]; then
+        install -m 644 ${B}/${GRUB_IMAGE} ${D}${EFI_BOOT_PATH}/${efi_target}
+    fi
 }
 
 FILES_${PN} += "${EFI_BOOT_PATH}"


### PR DESCRIPTION

Otherwise signed grub image in ${D} is replaced by unsigned one, hence the
unsigned one is packaged into RPM.

That is not a right behavior.

Signed-off-by: Yunguo Wei <yunguo.wei@windriver.com>