### PR TITLE
meta: drop ${COREBASE}/LICENSE references

### DIFF
--- a/recipes-extended/packagegroups/packagegroup-samples.bb
+++ b/recipes-extended/packagegroups/packagegroup-samples.bb
@@ -5,7 +5,7 @@
 DESCRIPTION = "Packagegroup to build RPMs used for samples."
 
 LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://${COREBASE}/LICENSE;md5=4d92cd373abda3937c2bc47fbc49d690"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
 WR_MACHINE_ESSENTIAL_EXTRA_RDEPENDS ?= ""
 ALLOW_EMPTY_packagegroup-samples = "1"

--- a/recipes-extended/packagegroups/packagegroup-webserver.bb
+++ b/recipes-extended/packagegroups/packagegroup-webserver.bb
@@ -5,7 +5,7 @@
 DESCRIPTION = "Packagegroup to build RPMs used for webserver."
 
 LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://${COREBASE}/LICENSE;md5=4d92cd373abda3937c2bc47fbc49d690"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
 WR_MACHINE_ESSENTIAL_EXTRA_RDEPENDS ?= ""
 ALLOW_EMPTY_packagegroup-webserver = "1"

--- a/recipes-samples/gcc-example/gcc-example_1.0.bb
+++ b/recipes-samples/gcc-example/gcc-example_1.0.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "The Pulsar gcc compile example test cases"
 SECTION = "GCC Example Test"
 LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://${COREBASE}/LICENSE;md5=4d92cd373abda3937c2bc47fbc49d690"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 PACKAGES = "gcc-example"
 RDEPENDS_${PN} += "gcc g++"
 

--- a/recipes-support/rpm-tool/nativesdk-rpm-tool_1.0.bb
+++ b/recipes-support/rpm-tool/nativesdk-rpm-tool_1.0.bb
@@ -4,7 +4,7 @@
 
 DESCRIPTION = "The offline tool to generate RPM with IMA and GPG signature"
 LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://${COREBASE}/LICENSE;md5=4d92cd373abda3937c2bc47fbc49d690"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
 S="${WORKDIR}"
 


### PR DESCRIPTION
The top level LICENSE file is not actually a license, it refers
other licenses that are used by Bitbake and Meta-data. Relying
on this file could cause problems for recipes when this file
changes, which it is about to.

Signed-off-by: Ming Liu <ming.liu@windriver.com>