### PR TITLE
libsolv: fix a kernel-devsrc installation issue

### DIFF
--- a/recipes-extended/libsolv/files/0001-repo_rpmdb.c-increase-MAX_HDR_CNT-and-MAX_HDR_DSIZE.patch
+++ b/recipes-extended/libsolv/files/0001-repo_rpmdb.c-increase-MAX_HDR_CNT-and-MAX_HDR_DSIZE.patch
@@ -1,0 +1,35 @@
+From 1c4c935cb73ac1ccb9693df1a51ba218a22e8ca8 Mon Sep 17 00:00:00 2001
+From: Ming Liu <liu.ming50@gmail.com>
+Date: Sat, 30 Sep 2017 11:15:16 +0800
+Subject: [PATCH] repo_rpmdb.c: increase MAX_HDR_CNT and MAX_HDR_DSIZE
+
+Upstream-Status: Submitted [https://github.com/openSUSE/libsolv/pull/230]
+
+We encountered 'corrupt rpm' issues when installing extreme big RPM
+packages like the kernel-devsrc package of Yocto project.
+
+It can be fixed by increasing MAX_HDR_CNT and MAX_HDR_DSIZE per test.
+
+Signed-off-by: Ming Liu <liu.ming50@gmail.com>
+---
+ ext/repo_rpmdb.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/ext/repo_rpmdb.c b/ext/repo_rpmdb.c
+index c7000a9..7000835 100644
+--- a/ext/repo_rpmdb.c
++++ b/ext/repo_rpmdb.c
+@@ -170,8 +170,8 @@
+ #define MAX_SIG_CNT		0x100000
+ #define MAX_SIG_DSIZE		0x100000
+ 
+-#define MAX_HDR_CNT		0x100000
+-#define MAX_HDR_DSIZE		0x2000000
++#define MAX_HDR_CNT		0x200000
++#define MAX_HDR_DSIZE		0x4000000
+ 
+ typedef struct rpmhead {
+   int cnt;
+-- 
+2.7.4
+

--- a/recipes-extended/libsolv/libsolv_0.6.28.bbappend
+++ b/recipes-extended/libsolv/libsolv_0.6.28.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI_append = " \
+    file://0001-repo_rpmdb.c-increase-MAX_HDR_CNT-and-MAX_HDR_DSIZE.patch \
+"


### PR DESCRIPTION
We encountered a problem when installing kernel-devsrc package on a
intel-x86 target, as follows:
$ dnf install kernel-devsrc
...
Installing : kernel-devsrc-1.0-r0.0.intel_corei7_64 1/1
failed loading RPMDB
The downloaded packages were saved in cache until the next successful transaction.
You can remove cached packages by executing 'dnf clean packages'.
...

It can be fixed by increasing MAX_HDR_CNT and MAX_HDR_DSIZE in libsolv
per test.

Signed-off-by: Ming Liu <ming.liu@windriver.com>