### PR TITLE
shim: taking fallback out from secure boot

### DIFF
--- a/recipes-bsp/shim/shim_git.bbappend
+++ b/recipes-bsp/shim/shim_git.bbappend
@@ -1,0 +1,7 @@
+EXTRA_OEMAKE_remove += "\
+    OVERRIDE_SECURITY_POLICY=1 \
+"
+
+FILES_${PN} = "/boot/efi/EFI/BOOT/bootx64.efi \
+               /boot/efi/EFI/BOOT/mmx64.efi \
+               "


### PR DESCRIPTION
fallback has some problem with MOK verify protocol, so taking it out.

This is a temp patch, will be removed when upstream integrates this
change.

The following warning will be shown, but ignore them for now:
WARNING: shim-12+gitAUTOINC+5202f80c32-r0 do_package: QA Issue: shim:
Files/directories were installed but not shipped in any package:
  /boot/efi/EFI/BOOT/bootx64.csv
  /boot/efi/EFI/BOOT/fbx64.efi

Signed-off-by: Yunguo Wei <yunguo.wei@windriver.com>