### PR TITLE
Remove ima-tool and repo-tool

### DIFF
--- a/recipes-support/rpm-tool/nativesdk-rpm-tool_1.0.bb
+++ b/recipes-support/rpm-tool/nativesdk-rpm-tool_1.0.bb
@@ -11,14 +11,10 @@ S="${WORKDIR}"
 inherit nativesdk
 
 SRC_URI = "file://rpm-tool \
-           file://ima-tool \
-           file://repo-tool \
            "
 do_install () {
 	install -d ${D}/${sbindir}
 	install -m 0755 ${S}/rpm-tool ${D}/${sbindir}/
-	install -m 0755 ${S}/ima-tool ${D}/${sbindir}/
-	install -m 0755 ${S}/repo-tool ${D}/${sbindir}/
 }
 
-FILES_${PN} = "${sbindir}/rpm-tool ${sbindir}/ima-tool ${sbindir}/repo-tool"
+FILES_${PN} = "${sbindir}/rpm-tool"


### PR DESCRIPTION
We don't needd ima-tool anymore, as IMA signing is done via 'rpmsign'.

repo-tool is integrated into rpm-tool.

Signed-off-by: Yunguo Wei <yunguo.wei@windriver.com>