### PR TITLE
Fixes for rpm-tool

### DIFF
--- a/recipes-support/rpm-tool/rpm-tool/rpm-tool
+++ b/recipes-support/rpm-tool/rpm-tool/rpm-tool
@@ -52,6 +52,7 @@ sdk_native_dir=`env |grep OECORE_NATIVE_SYSROOT|cut -d= -f2`
 repo_sign=0
 repo_dir=""
 enable_ima=0
+pkg_arch="noarch"
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -107,6 +108,10 @@ while [ $# -gt 0 ]; do
 		;;
         --rpm-dir)
 		rpm_dir="$2"
+		shift
+		;;
+        --pkg-arch)
+		pkg_arch="$2"
 		shift
 		;;
 	--help)
@@ -195,7 +200,7 @@ setup_env() {
     # setup variables for packaging and signing
     if [ $pkg_sign -eq 1 ]; then
 	rpmbuild_bin=$sdk_dir/sysroots/x86_64-wrlinuxsdk-linux/usr/bin/rpmbuild
-        rpm_file=${rpm_dir}/${pkg_name}-${pkg_version}-${pkg_release}.${ARCH}.rpm
+        rpm_file=${rpm_dir}/${pkg_name}-${pkg_version}-${pkg_release}.${pkg_arch}.rpm
 	if [ x$install_dir == x ]; then
 	    echo "Please specify application install directory ..."
 	    exit 1
@@ -282,7 +287,7 @@ function generate_rpm() {
 
     # generate rpm
     rpmbuild_bin=$sdk_dir/sysroots/x86_64-wrlinuxsdk-linux/usr/bin/rpmbuild
-    $rpmbuild_bin --noclean --nodeps --short-circuit --target ${ARCH}-wrs-linux \
+    $rpmbuild_bin --noclean --nodeps --short-circuit --target ${pkg_arch}-wrs-linux \
 		   --buildroot ${install_dir} \
 		   --define '_rpmdir '${rpm_dir}'' \
 		   --define '_build_name_fmt %%{NAME}-%%{VERSION}-%%{RELEASE}.%%{ARCH}.rpm' \

--- a/recipes-support/rpm-tool/rpm-tool/rpm-tool
+++ b/recipes-support/rpm-tool/rpm-tool/rpm-tool
@@ -23,8 +23,9 @@ usage() {
     echo >&2 "   --ima-key The IMA private key file for IMA signing."
     echo >&2 "   --ima-pass IMA key password"
     echo >&2 "   --rpm-dir The output directory, where the package is generated."
-    echo >&2 "   --sign-repo Sign/Resign the whole repo with IMA and GPG key."
+    echo >&2 "   --repo-sign Sign/Resign the whole repo with IMA and GPG key."
     echo >&2 "   --repo-dir The repo directory to be signed."
+    echo >&2 "   --pkg-arch The architecture of the package."
     exit 1
 }
 
@@ -114,7 +115,7 @@ while [ $# -gt 0 ]; do
 		pkg_arch="$2"
 		shift
 		;;
-	--help)
+	--help|-h)
 		usage
 		;;
         *)


### PR DESCRIPTION
1. Add --pkg-arch option to specify a package's architecture
2. Minor fix for help info.