### PR TITLE
dbus: fix defect about machine id change after system upgrade

### DIFF
--- a/recipes-core/dbus/dbus_1.8.20.bbappend
+++ b/recipes-core/dbus/dbus_1.8.20.bbappend
@@ -1,3 +1,16 @@
+#
+# Copyright (C) 2014 Wind River Systems, Inc.
+#
+# LOCAL REV: add WR specific scripts
+#
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI += "\
+    file://0001-generate-machine-id-in-dbus-service.patch \
+"
+
 pkg_postinst_dbus_prepend() {
+	dbus-uuidgen --ensure 2>/dev/null
 	readlink -f /sbin/init | grep systemd && exit 0
 }

--- a/recipes-core/dbus/files/0001-generate-machine-id-in-dbus-service.patch
+++ b/recipes-core/dbus/files/0001-generate-machine-id-in-dbus-service.patch
@@ -1,0 +1,28 @@
+From b40885e6945d703877d65e9a5602f4e9856c0766 Mon Sep 17 00:00:00 2001
+From: Guojian Zhou <guojian.zhou@windriver.com>
+Date: Tue, 28 Nov 2017 07:18:23 +0000
+Subject: [PATCH] Generate dbus machine id in dbus systemd service
+
+Use command 'dbus-uuidgen --ensure' to generate machine id in
+/var/lib/dbus/machine-id
+
+Signed-off-by: De Huo <De.Huo@windriver.com>
+---
+ bus/dbus.service.in | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/bus/dbus.service.in b/bus/dbus.service.in
+index 3bc4726..8cf52d5 100644
+--- a/bus/dbus.service.in
++++ b/bus/dbus.service.in
+@@ -4,6 +4,7 @@ Documentation=man:dbus-daemon(1)
+ Requires=dbus.socket
+ 
+ [Service]
++ExecStartPre=@EXPANDED_BINDIR@/dbus-uuidgen --ensure
+ ExecStart=@EXPANDED_BINDIR@/dbus-daemon --system --address=systemd: --nofork --nopidfile --systemd-activation
+ ExecReload=@EXPANDED_BINDIR@/dbus-send --print-reply --system --type=method_call --dest=org.freedesktop.DBus / org.freedesktop.DBus.ReloadConfig
+ OOMScoreAdjust=-900
+-- 
+2.7.4
+


### PR DESCRIPTION
Issue: LINPUL8-764

Add command 'dbus-uuidgen --ensure' in dbus service and rpm
postinstall script to generate /var/lib/dbus/machine-id which is
used to backup the machine-id for systemd.

Signed-off-by: De Huo <De.Huo@windriver.com>