### PR TITLE
packagegroup-rpmfeed: fix links-x11 confict with links

### DIFF
--- a/recipes-extended/packagegroups/packagegroup-rpmfeed.bb
+++ b/recipes-extended/packagegroups/packagegroup-rpmfeed.bb
@@ -13,8 +13,7 @@ RDEPENDS_${PN} = "\
     docker \
     kernel-dev \
     kernel-devsrc \
-    links \
-    links-x11 \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'links-x11', 'links', d)} \
     tsocks \
     \
     packagegroup-samples \


### PR DESCRIPTION
It fixed the do_rootfs failure:
...
Error:
 Problem: package links-x11-2.7-r0.0.core2_64 conflicts with links provided by links-2.7-r0.0.core2_64
  - package packagegroup-rpmfeed-1.0-r0.0.noarch requires links-x11, but none of the providers can be installed
  - package packagegroup-rpmfeed-1.0-r0.0.noarch requires links, but none of the providers can be installed
  - conflicting requests
...

Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>