### PR TITLE
nxp-imx:reserve 1M space for bootloader in wks

### DIFF
--- a/scripts/lib/wic/canned-wks/cube-gw-ostree-runtime-nxp-imx6.wks
+++ b/scripts/lib/wic/canned-wks/cube-gw-ostree-runtime-nxp-imx6.wks
@@ -1,5 +1,5 @@
 #bootloader --ptable gpt
-part / --source rawcopy --sourceparams="file=u-boot.imx" --ondisk mmcblk --no-table --align 1
+part / --source rawcopy --sourceparams="file=u-boot.imx" --ondisk mmcblk --no-table --align 1 --size 1
 part /boot --source bootimg-partition --ondisk mmcblk --fstype=vfat --label boot --active --align 4 --size 16
 part / --source rawcopy --sourceparams="file=cube-gw-ostree-runtime-nxp-imx6_boot.otaimg" --ondisk mmcblk --fstype=ext4 --label otaboot --align 4 --type logical
 part / --source rawcopy --sourceparams="file=cube-gw-ostree-runtime-nxp-imx6.otaimg" --ondisk mmcblk --fstype=ext4 --label otaroot --align 4 --type logical

--- a/scripts/lib/wic/canned-wks/seco-image-minimal-ostree-runtime-nxp-imx6.wks
+++ b/scripts/lib/wic/canned-wks/seco-image-minimal-ostree-runtime-nxp-imx6.wks
@@ -1,4 +1,4 @@
-part / --source rawcopy --sourceparams="file=u-boot.imx" --ondisk mmcblk --no-table --align 1
+part / --source rawcopy --sourceparams="file=u-boot.imx" --ondisk mmcblk --no-table --align 1 --size 1
 part /boot --source bootimg-partition --ondisk mmcblk --fstype=vfat --label boot --active --align 4 --size 16
 part / --source rawcopy --sourceparams="file=seco-image-minimal-ostree-runtime-nxp-imx6_boot.otaimg" --ondisk mmcblk --fstype=ext4 --label otaboot --align 4 --type logical
 part / --source rawcopy --sourceparams="file=seco-image-minimal-ostree-runtime-nxp-imx6.otaimg" --ondisk mmcblk --fstype=ext4 --label otaroot --align 4 --type logical


### PR DESCRIPTION
Reserve 1M space for bootloader in wks for nxp-imx6 bsp.

Signed-off-by: Jiang Lu <lu.jiang@windriver.com>